### PR TITLE
add `/learn` command

### DIFF
--- a/app/middleware/llm_task.py
+++ b/app/middleware/llm_task.py
@@ -151,7 +151,7 @@ class OpenaiMiddleware(object):
         message_run = []
         if isinstance(system_prompt, str):
             message_run.append(SystemMessage(content=system_prompt))
-        history = await self.message_history.read(lines=10)
+        history = await self.message_history.read(lines=8)
         logger.trace(f"History message {history}")
         for de_active_message in history:
             try:

--- a/app/sender/discord/__init__.py
+++ b/app/sender/discord/__init__.py
@@ -36,6 +36,7 @@ from ..util_func import (
     uid_make,
     save_credential,
     dict2markdown,
+    learn_instruction,
 )
 from llmkira.openapi.trigger import get_trigger_loop
 from ...components.credential import Credential, ProviderError
@@ -261,6 +262,18 @@ class DiscordBotRunner(Runner):
                     content="\nLogin success as provider! Welcome master!",
                     ephemeral=True,
                 )
+
+        @client.include
+        @crescent.command(
+            dm_enabled=True,
+            name="learn",
+            description="Set instruction text",
+        )
+        async def listen_learn_command(ctx: crescent.Context, instruction: str):
+            reply = await learn_instruction(
+                uid=uid_make(__sender__, ctx.user.id), instruction=instruction
+            )
+            return await ctx.respond(content=convert(reply), ephemeral=True)
 
         @client.include
         @crescent.command(

--- a/app/sender/discord/event.py
+++ b/app/sender/discord/event.py
@@ -19,6 +19,7 @@ def help_message():
     `/login` - login
     `/login_via_url` - login via url
     `/env` - set environment variable, split by ; ,  use `/env ENV=NONE` to disable a env.
+    `/learn` - set your system prompt, reset by `/learn reset`
 
 **Please confirm that that bot instance is secure, some plugins may be dangerous on unsafe instance.**
 """.format(prefix=BotSetting.prefix)

--- a/app/sender/kook/__init__.py
+++ b/app/sender/kook/__init__.py
@@ -33,6 +33,7 @@ from ..util_func import (
     uid_make,
     save_credential,
     dict2markdown,
+    learn_instruction,
 )
 from llmkira.openapi.trigger import get_trigger_loop
 from ...components.credential import ProviderError, Credential
@@ -274,6 +275,21 @@ class KookBotRunner(Runner):
                     is_temp=True,
                     type=MessageTypes.KMD,
                 )
+
+        @bot.command(name="learn")
+        async def listen_learn_command(
+            msg: Message,
+            instruction: str,
+        ):
+            reply = await learn_instruction(
+                uid=uid_make(__sender__, msg.author_id),
+                instruction=instruction,
+            )
+            return await msg.reply(
+                content=convert(reply),
+                is_temp=True,
+                type=MessageTypes.KMD,
+            )
 
         @bot.command(name="login")
         async def listen_login_command(

--- a/app/sender/kook/event.py
+++ b/app/sender/kook/event.py
@@ -38,6 +38,7 @@ def help_message():
     `/login` - login openai
     `/login_via_url` - login via provider url
     `/env` - set environment variable, split by ; ,  use `/env ENV=NONE` to disable a env.
+    `/learn` - set your system prompt, reset by `/learn reset`
 
 **Please confirm that that bot instance is secure, some plugins may be dangerous on unsafe instance.**
 """.format(prefix=BotSetting.prefix)

--- a/app/sender/slack/__init__.py
+++ b/app/sender/slack/__init__.py
@@ -24,6 +24,7 @@ from app.sender.util_func import (
     uid_make,
     login,
     dict2markdown,
+    learn_instruction,
 )
 from app.setting.slack import BotSetting
 from llmkira.kv_manager.env import EnvManager
@@ -222,6 +223,18 @@ class SlackBotRunner(Runner):
                     )
             except Exception as e:
                 logger.exception(e)
+
+        @bot.command(command="/learn")
+        async def listen_learn_command(ack: AsyncAck, respond: AsyncRespond, command):
+            command: SlashCommand = SlashCommand.model_validate(command)
+            await ack()
+            if not command.text:
+                return
+            _arg = command.text
+            reply = await learn_instruction(
+                uid=uid_make(__sender__, command.user_id), instruction=_arg
+            )
+            return await respond(text=reply)
 
         @bot.command(command="/login")
         async def listen_login_command(ack: AsyncAck, respond: AsyncRespond, command):

--- a/app/sender/slack/event.py
+++ b/app/sender/slack/event.py
@@ -25,6 +25,7 @@ def help_message():
 `/auth` - activate a task (my power),but outside the thread
 `/login` - login via url or raw
 `/env` - set environment variable, split by ; ,  use `/env ENV=NONE` to disable a env.
+`/learn` - set your system prompt, reset by `/learn reset`
 
 Make sure you invite me before you call me in channel, wink~
 

--- a/app/sender/telegram/__init__.py
+++ b/app/sender/telegram/__init__.py
@@ -142,7 +142,6 @@ class TelegramBotRunner(Runner):
                     message.text = message.text[5:]
                 if message.text.startswith("/ask"):
                     message.text = message.text[4:]
-                message.text = message.text
             if not message.text:
                 return None
             __used_file_id = []

--- a/app/sender/telegram/__init__.py
+++ b/app/sender/telegram/__init__.py
@@ -22,6 +22,7 @@ from app.sender.util_func import (
     login,
     TimerObjectContainer,
     dict2markdown,
+    learn_instruction,
 )
 from app.setting.telegram import BotSetting
 from llmkira.kv_manager.env import EnvManager
@@ -226,6 +227,15 @@ class TelegramBotRunner(Runner):
                     await bot.reply_to(message, text=logs)
             except Exception as e:
                 logger.exception(e)
+
+        @bot.message_handler(commands="learn", chat_types=["private"])
+        async def listen_learn_command(message: types.Message):
+            logger.debug("Debug:learn command")
+            _cmd, _arg = parse_command(command=message.text)
+            reply = await learn_instruction(
+                uid=uid_make(__sender__, message.from_user.id), instruction=_arg
+            )
+            await bot.reply_to(message, text=reply)
 
         @bot.message_handler(commands="login", chat_types=["private"])
         async def listen_login_command(message: types.Message):

--- a/app/sender/telegram/event.py
+++ b/app/sender/telegram/event.py
@@ -7,17 +7,18 @@
 
 def help_message():
     return """
-    /help - HELP YOURSELF
-    /chat - Chat with me :)
-    /task - Function enable
-    /ask - Chat with func_disable, 禁止函数
-    /tool - 工具列表
-    /clear - 删除自己的记录
-    /auth - POWER
+    /help - show help message
+    /chat - just want to chat with me
+    /task - chat with function_enable
+    /ask - chat with function_disable
+    /tool - check all useful tools
+    /clear - clear the chat history
+    /auth - auth the tool_call
+    /learn - set your system prompt, reset by `/learn reset`
 
 Private Chat Only:
     /login - login via url or something
-    /env - 配置变量 split by ; ,  use `/env ENV=NONE` to disable a env.
+    /env - set v-env split by ; ,  use `/env ENV=NONE` to disable a env.
 
 !Please confirm that that bot instance is secure, some plugins may be dangerous on unsafe instance.
 """

--- a/app/sender/util_func.py
+++ b/app/sender/util_func.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from app.components.credential import Credential, ProviderError
 from app.components.user_manager import USER_MANAGER
+from llmkira.kv_manager.instruction import InstructionManager
 from llmkira.task import Task
 from llmkira.task.snapshot import SnapData, global_snapshot_storage
 
@@ -110,6 +111,11 @@ async def auth_reloader(snapshot_credential: str, platform: str, user_id: str) -
 
 
 def split_setting_string(input_string):
+    """
+    Split setting string
+    :param input_string: input string
+    :return: list or None
+    """
     if not isinstance(input_string, str):
         return None
     segments = input_string.split("$")
@@ -135,7 +141,32 @@ async def save_credential(uid, credential: Credential):
     await USER_MANAGER.save(user_model=user)
 
 
+async def learn_instruction(uid: str, instruction: str) -> str:
+    """
+    Set instruction text
+    :param uid: uid_make
+    :param instruction: instruction text
+    :return: str message
+    """
+    if len(instruction) > 1500:
+        return "your instruction text length should be less than 1500"
+    manager = InstructionManager(user_id=uid)
+    if len(instruction) < 7:
+        instruction = ""
+        await manager.set_instruction(instruction)
+        return "I already reset your instruction to default..."
+    else:
+        await manager.set_instruction(instruction)
+        return "I keep it in my mind!"
+
+
 async def login(uid: str, arg_string) -> str:
+    """
+    Login as provider or model
+    :param uid: uid_make
+    :param arg_string: input string
+    :return: str message
+    """
     error = telegramify_markdown.convert(
         "🔑 **Incorrect format.**\n"
         "You can set it via `https://<something api.openai.com>/v1$<api key>"

--- a/llmkira/extra/plugins/search/engine.py
+++ b/llmkira/extra/plugins/search/engine.py
@@ -62,7 +62,7 @@ async def search_in_duckduckgo(search_sentence: str):
             _build_result.append(
                 SearchEngineResult(
                     title=result.get("title", "Undefined"),
-                    link=result.get("Href", "Undefined"),
+                    link=result.get("href", "Undefined"),
                     snippet=result.get("body", "Undefined"),
                 )
             )

--- a/llmkira/kv_manager/instruction.py
+++ b/llmkira/kv_manager/instruction.py
@@ -23,10 +23,13 @@ class InstructionManager(KvManager):
         return f"instruction:{key}"
 
     async def read_instruction(self) -> str:
+        """
+        读取指令，如果没有指令则返回默认指令，指令长度大于5，否则返回默认指令
+        """
         result = await self.read_data(self.user_id)
-        if not result:
-            return f"Now={time_now()}\n{DEFAULT_INSTRUCTION}"
-        return f"Now={time_now()}\n{result}"
+        if isinstance(result, str) and len(result) > 5:
+            return f"Now={time_now()}\n{result}"
+        return f"Now={time_now()}\n{DEFAULT_INSTRUCTION}"
 
     async def set_instruction(self, instruction: str) -> str:
         if not isinstance(instruction, str):

--- a/llmkira/openapi/trigger/__init__.py
+++ b/llmkira/openapi/trigger/__init__.py
@@ -44,10 +44,10 @@ async def get_trigger_loop(platform_name: str, message: str, uid: str = None):
     message: Message Content
     :return 如果有触发，则返回触发的action，否则返回None 代表没有操作
     """
-    sorted(__trigger_phrases__, key=lambda x: x.priority)
+    trigger_sorted = sorted(__trigger_phrases__, key=lambda x: x.priority)
     if not message:
         message = ""
-    for trigger in __trigger_phrases__:
+    for trigger in trigger_sorted:
         if trigger.on_platform == platform_name:
             try:
                 if await trigger.on_func(message, uid):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llmkira"
-version = "1.0.4"
+version = "1.0.5"
 description = "A chain message bot based on OpenAI"
 authors = [
     { name = "sudoskys", email = "me@dianas.cyou" },


### PR DESCRIPTION
Provide methods to customize system prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `/learn` command across various platforms (Discord, Slack, Kook, Telegram) to set and reset the system prompt.
  - Enhanced help messages and command descriptions in Telegram for better user interaction.
  
- **Bug Fixes**
  - Corrected the key for fetching links in the DuckDuckGo search functionality to improve accuracy.

- **Refactor**
  - Streamlined message history processing by reducing the number of lines read, enhancing performance.
  - Implemented sorting of trigger phrases by priority for more efficient processing.

- **Documentation**
  - Updated and added new function documentation and type hints to improve code readability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->